### PR TITLE
added links for all CV and ML conferences

### DIFF
--- a/conferences/README.md
+++ b/conferences/README.md
@@ -16,24 +16,24 @@
 
 ## Machine Learning
 ### Conferences
-1. **Neural Information Processing Systems (NeurIPS)**: Good for theoretical research in Machine Learning and Computational Neuroscience
-2. **International Conference on Learning Representations (ICLR)**: Good for theoretical research in Deep Learning and Representation Learning
-3. **International Conference on Machine Learning (ICML)**: Good for theoretical research in Machine Learning, papers are published in JMLR
-4. **Conference on Learning Theory (CoLT)**: Pure theoretical machine learning conference
-5. **Reinforcement Learning and Decision Making (RLDM)**: This is the only conference dedicated to pure RL
-6. **Association for the Advancement of Artificial Intelligence (AAAI) Conference**: Covers wide variety of topics in AI
-7. **International Conference on Artificial Intelligence and Statistics (AISTATS)**: Theoretical conference for Statistics and Machine Learning
+1. [Neural Information Processing Systems (NeurIPS)](https://neurips.cc/): Good for theoretical research in Machine Learning and Computational Neuroscience
+2. [International Conference on Learning Representations (ICLR)](https://iclr.cc/): Good for theoretical research in Deep Learning and Representation Learning
+3. [International Conference on Machine Learning (ICML)](https://icml.cc/): Good for theoretical research in Machine Learning, papers are published in JMLR
+4. [Conference on Learning Theory (CoLT)](https://www.colt2020.org/): Pure theoretical machine learning conference
+5. [Reinforcement Learning and Decision Making (RLDM)](http://rldm.org/): This is the only conference dedicated to pure RL
+6. [Association for the Advancement of Artificial Intelligence (AAAI) Conference](https://www.aaai.org/Conferences/AAAI/aaai.php): Covers wide variety of topics in AI
+7. [International Conference on Artificial Intelligence and Statistics (AISTATS)](https://www.aistats.org/): Theoretical conference for Statistics and Machine Learning
 
 ### Journals
-1. **Journal of Machine Learning Research (JMLR)**: Top journal for Machine Learning research
+1. [Journal of Machine Learning Research (JMLR)](http://www.jmlr.org/): Top journal for Machine Learning research
 
 ## Computer Vision
 ### Conferences
-1. **IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)**: Highest-rated conference among all engineering disciplines
-2. **European Conference on Computer Vision (ECCV) (even year) / IEEE/CVF International Conference on Computer Vision (ICCV) (odd year)**: Good for theoretical as well as application-based research in Computer Vision and Pattern Recognition
-3. **British Machine Vision Conference (BMVC)**: Good for theoretical as well as application-based research in Computer Vision
-4. **Workshop on Applications of Computer Vision (WACV)**: More focused towards applications in Computer Vision
+1. [IEEE/CVF Conference on Computer Vision and Pattern Recognition (CVPR)](http://cvpr2020.thecvf.com/): Highest-rated conference among all engineering disciplines
+2. [European Conference on Computer Vision (ECCV) (even year)](https://eccv2020.eu/) / [IEEE/CVF International Conference on Computer Vision (ICCV) (odd year)](http://iccv2021.thecvf.com/home): Good for theoretical as well as application-based research in Computer Vision and Pattern Recognition
+3. [British Machine Vision Conference (BMVC)](https://britishmachinevisionassociation.github.io/bmvc): Good for theoretical as well as application-based research in Computer Vision
+4. [Workshop on Applications of Computer Vision (WACV)](http://wacv2021.thecvf.com/home): More focused towards applications in Computer Vision
 
 ### Journals
-1. **IEEE Transactions on Pattern Analysis and Machine Intelligence (IEEE TPAMI)**
-2. **IEEE Transactions on Image Processing**
+1. [IEEE Transactions on Pattern Analysis and Machine Intelligence (IEEE TPAMI)](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=34)
+2. [IEEE Transactions on Image Processing](https://ieeexplore.ieee.org/xpl/RecentIssue.jsp?punumber=83)


### PR DESCRIPTION
Added links to conferences and journals as discussed in and for closing #39. @SharathRaparthy and @take2rohit, please go through and let me know if any changes are required.